### PR TITLE
trigger a zipchange on change events as well to catch browser autofills

### DIFF
--- a/jquery.ziptastic.js
+++ b/jquery.ziptastic.js
@@ -36,7 +36,7 @@
 		return this.each(function() {
 			var ele = $(this);
 
-			ele.on('keyup', function() {
+			ele.on('keyup change', function() {
 				var zip = ele.val();
 
 				// TODO Non-US zip codes?


### PR DESCRIPTION
Triggering zipchange on "change" (in addition to "keyup") fixes #15 for Chromium/Chrome autofill.